### PR TITLE
Fix "Attempt to call nil 'seek'" on non-latest CC:T versions

### DIFF
--- a/Blockman.lua
+++ b/Blockman.lua
@@ -608,7 +608,7 @@ local function changeTrack()
     displayphrase = "Loading Track..."
     refreshGrey()
     decoder = dfpwm.make_decoder()
-    audiohandle = http.get(musicdata[albumplaying][trackplaying]["tracklink"])
+    audiohandle = http.get(musicdata[albumplaying][trackplaying]["tracklink"], nil, true)
     if audiohandle then
         getDuration()
         displayphrase = " "


### PR DESCRIPTION
CC:T unified all read handles into binary handles recently, this means that if we want to use `.seek` on any read handles in older CC/Minecraft versions, we need to open the file (or http request) in binary mode.

I am not sure if there is anything else that should be handled in binary form here, but this is at least what is causing the error being reported on Discord.